### PR TITLE
Update usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ steps:
   with:
     ruby-version: ruby
 
-- uses: licensee/setup-licensed@v1
+- uses: licensee/setup-licensed@v1.3.2
   with:
     version: '4.x' # required: supports matching based on string equivalence or node-semver range
     install-dir: /path/to/install/at # optional: defaults to /usr/local/bin


### PR DESCRIPTION
github actions returns:
```
Error: Unable to resolve action `licensee/setup-licensed@v1`, unable to find version `v1`
```
using the current instruction. Updates it to the last available release.

it also resolves #13 
